### PR TITLE
fix: constrain board to screen on landscape iPad

### DIFF
--- a/src/js/wc/TTTGame.ts
+++ b/src/js/wc/TTTGame.ts
@@ -13,18 +13,20 @@ const styles = `
     --game-padding:
         max(1rem, 5vw)
         max(2rem, 5vw);
-  }
 
-  :host {
     background-color: var(--gray-100);
     border: 1px solid var(--game-border-color);
     box-shadow: var(--game-box-shadow);
     padding: var(--game-padding);
-    width: max(220px, 45vmin);
-    // max-height: 75vh;
-    // height: clamp(423px, 0vh, 75vh);
+    width: max(220px, 40vmin);
     transform: translateY(-2.5vh);
+  }
 
+
+  @media (orientation: landscape) {
+    :host {
+      transform: translateY(0);
+    }
   }
 
   :host([data-current-player="x"]) {

--- a/src/js/wc/ThemeSelector.ts
+++ b/src/js/wc/ThemeSelector.ts
@@ -3,7 +3,7 @@ import sounds from "../sounds";
 const style = `
   :host  {
     --width: 3rem;
-    --height: max(1.5rem, 4vmin);
+    --height: clamp(1.5rem, 4vmin, 2rem);
     --icon-font-size: 1.15rem;
     --bottom-inset: 1.25rem;
     --right-inset: 2.5rem;
@@ -12,14 +12,13 @@ const style = `
     bottom: var(--bottom-inset);
     right: var(--right-inset);
 
-    width: var(--width);
     height: var(--height);
+    aspect-ratio: 1.6;
   }
 
   @media (min-width: 768px) {
     :host {
       --width: 4rem;
-      // --height: 2.5rem;
       --icon-font-size: 1.5rem;
       --bottom-inset: 1.5rem;
       --right-inset: 3rem;


### PR DESCRIPTION
Browser chrome like URL bar etc. takes up more space than expected
particularly on a landscape oriented iPad.